### PR TITLE
Add all EventEmitter methods to SYNC_METHODS

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,16 +11,21 @@ var ASYNC_METHODS = ['publish',
 ];
 
 var SYNC_METHODS = [
-  'emit',
   'addListener',
+  'emit',
+  'eventNames',
+  'getMaxListeners',
+  'listenerCount',
+  'listeners',
+  'off',
   'on',
   'once',
-  'removeListener',
+  'prependListener',
+  'prependOnceListener',
   'removeAllListeners',
+  'removeListener',
   'setMaxListeners',
-  'getMaxListeners',
-  'listeners',
-  'listenerCount'
+  'rawListeners'
 ];
 
 module.exports = {


### PR DESCRIPTION
I was tripped up by the lack of .off, so I added all of them. These are in the order at https://nodejs.org/api/events.html.