### PR TITLE
Fix test not ending properly

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Server = require('mqtt/test/server');
 
 const AsyncMQTT = require('./');
@@ -19,7 +21,10 @@ function runTests () {
     const client = AsyncMQTT.connect(SERVER_URL);
 
     t.ok(client instanceof AsyncClient, 'Connect returned an AsyncClient');
-    client.end();
+
+    client.on('connect', () => {
+      client.end();
+    })
   });
 
   test('Should be able to listen on event on client', t => {


### PR DESCRIPTION
Test takes way too long to end because one client did not close connection properly. I guess it is because you should call `client.end` only  after client has connected.