### PR TITLE
Add 'connectAsync' method to types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,5 +68,6 @@ export declare class AsyncMqttClient extends MqttClient {
 }
 
 export declare function connect (brokerUrl?: string | any, opts?: IClientOptions): AsyncMqttClient
+export declare function connectAsync (brokerUrl: string | any, opts?: IClientOptions, allowRetries?: boolean): Promise<AsyncMqttClient>
 
 export { AsyncMqttClient as AsyncClient }


### PR DESCRIPTION
This PR adds the missing method `connectAsync(..)` to the index.d.ts file