### PR TITLE
Add reconnect method and test.

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,10 @@ class AsyncClient {
     })
   }
 
+  reconnect (...args) {
+    return this._client.reconnect(...args);
+  }
+
   addListener (...args) {
     return this._client.addListener(...args);
   }

--- a/test.js
+++ b/test.js
@@ -131,6 +131,26 @@ function runTests () {
       return client.end();
     });
   });
+
+  test('Calling reconnect after end should resolve once reconnect', t => {
+    t.plan(2);
+
+    const client = AsyncMQTT.connect(SERVER_URL);
+
+    client.once('reconnect', () => {
+      t.pass('Reconnect event occured');
+      client.once('connect', () => {
+        client.end();
+      });
+    });
+
+    client.once('connect', () => {
+      client.end().then(() => {
+        t.pass('End resolved');
+        client.reconnect();
+      });
+    });
+  });
 }
 
 // Taken from MQTT.js tests


### PR DESCRIPTION
Add reconnect method.
Add new test using reconnect method.

ps.
async-mqtt seems working with mqtt 3.0.0, but test case does not working because mqtt/test/server was changed on 3.0.0 version. (I tested with my own broker)
I think I have to change test function like using aedes not mqtt/test/server.