### PR TITLE
Update minimum required ESLint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.0.5",
-    "eslint": "^7.1.0",
+    "eslint": "^7.32.0",
     "mqtt-connection": "^4.0.0",
     "tape": "^5.0.0"
   }


### PR DESCRIPTION
Fixes #50

Update minimum required eslint version to 7.32.0, the last 7.x release.

According to their releases page, version 7.28.0 addressed this: https://github.com/eslint/eslint/tree/v7.28.0 (issue: https://github.com/eslint/eslint/pull/14658)