### PR TITLE
Add missing AsyncClient getters and setters for MqttClient properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,64 @@ class AsyncClient {
     return this._client.connected;
   }
 
+  set connected (connectedNew) {
+    this._client.connected = connectedNew;
+  }
+
+  get disconnecting () {
+    return this._client.disconnecting;
+  }
+
+  set disconnecting (disconnectingNew) {
+    this._client.disconnecting = disconnectingNew;
+  }
+
+  get disconnected () {
+    return this._client.disconnected;
+  }
+
+  set disconnected (disconnectedNew) {
+    this._client.disconnected = disconnectedNew;
+  }
+
   get reconnecting () {
     return this._client.reconnecting;
+  }
+
+  set reconnecting (reconnectingNew) {
+    this._client.reconnecting = reconnectingNew;
+  }
+
+  get incomingStore () {
+    return this._client.incomingStore;
+  }
+
+  set incomingStore (incomingStoreNew) {
+    this._client.incomingStore = incomingStoreNew;
+  }
+
+  get outgoingStore () {
+    return this._client.outgoingStore;
+  }
+
+  set outgoingStore (outgoingStoreNew) {
+    this._client.outgoingStore = outgoingStoreNew;
+  }
+
+  get options () {
+    return this._client.options;
+  }
+
+  set options (optionsNew) {
+    this._client.options = optionsNew;
+  }
+
+  get queueQoSZero () {
+    return this._client.queueQoSZero;
+  }
+
+  set queueQoSZero (queueQoSZeroNew) {
+    this._client.queueQoSZero = queueQoSZeroNew;
   }
 
   publish (...args) {


### PR DESCRIPTION
The type definitions claims that AsyncClient extends MqttClient, which implies that all of the public properties present on MqttClient can be accessed on AsyncClient. However, several of the getters and setters are missing. The full list added is:

Properties that had a getter but not setter (setter added):
- `connected`
- `reconnecting`

Properties that had neither (both added):
- `disconnecting`
- `disconnected`
- `incomingStore`
- `outgoingStore`
- `options`
- `queueQoSZero`

This will allow the AsyncClient to read and modify these values in the same manner as the base class client.