### PR TITLE
Exported UserProperties Type from mqtt

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ export {
   // mqtt-packet
   QoS,
   PacketCmd,
+  UserProperties,
   IPacket,
   IConnectPacket,
   IPublishPacket,


### PR DESCRIPTION
Hello! 

It would be nice to access UserProperties Type from async-mqtt.
By doing this, I only need to import 'async-mqtt' and not 'mqtt' as well 

regards,
Johann